### PR TITLE
Added wget flag to reset connection

### DIFF
--- a/cmake/install-share.sh
+++ b/cmake/install-share.sh
@@ -64,7 +64,7 @@ mkdir -p "$SUPPORT_DIR"
 # Get archive using wget.
 ARCH_URL="https://github.com/avast-tl/retdec-support/releases/download/$VERSION/$ARCH_NAME"
 echo "Downloading archive from $ARCH_URL ..."
-wget --no-verbose "$ARCH_URL" -O "$SUPPORT_DIR/$ARCH_NAME"
+wget --no-verbose --read-timeout=10 "$ARCH_URL" -O "$SUPPORT_DIR/$ARCH_NAME"
 WGET_RC=$?
 if [ "$WGET_RC" -ne 0 ]; then
 	echo "ERROR: wget failed"


### PR DESCRIPTION
Since install-sh.sh is a part of the install process, we probably don't want to wait for the long default of 15 minutes (https://github.com/chapmanb/bcbio-nextgen/issues/1487).

Was having issues on my build box before applying this change (connections to `*.s3.amazonaws.com` kept hanging).