### PR TITLE
fix path detection for symlinks & support cygwin paths via cygpath

### DIFF
--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -3,7 +3,7 @@
 # Decompiler's configuration. This file should be included in every decompilation script.
 #
 
-SCRIPTPATH="$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )"
+SCRIPTPATH="$(dirname "$(readlink -e "$0")")"
 
 if [ -z "$DECOMPILER_CONFIG" ]; then
 	DECOMPILER_CONFIG="./config.sh"

--- a/scripts/decompile-all.sh
+++ b/scripts/decompile-all.sh
@@ -8,7 +8,7 @@
 #  - the `find` and `timeout` commands
 #
 
-SCRIPTPATH="$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )"
+SCRIPTPATH="$(dirname "$(readlink -e "$0")")"
 
 if [ -z "$DECOMPILER_UTILS" ]; then
 	DECOMPILER_UTILS="$SCRIPTPATH/utils.sh"

--- a/scripts/decompile-archive.sh
+++ b/scripts/decompile-archive.sh
@@ -8,7 +8,7 @@
 #  - the `timeout` command
 #
 
-SCRIPTPATH="$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )"
+SCRIPTPATH="$(dirname "$(readlink -e "$0")")"
 
 if [ -z "$DECOMPILER_UTILS" ]; then
 	DECOMPILER_UTILS="$SCRIPTPATH/utils.sh"

--- a/scripts/decompile.sh
+++ b/scripts/decompile.sh
@@ -3,7 +3,7 @@
 # The script decompiles the given file into the selected target high-level language.
 #
 
-SCRIPTPATH="$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )"
+SCRIPTPATH="$(dirname "$(readlink -e "$0")")"
 
 if [ -z "$DECOMPILER_UTILS" ]; then
 	DECOMPILER_UTILS="$SCRIPTPATH/utils.sh"
@@ -162,10 +162,10 @@ check_arguments()
 	fi
 
 	# Convert to absolute paths.
-	IN=$(readlink -f "$IN")
-	OUT=$(readlink -f "$OUT")
+	IN=$(get_realpath "$IN")
+	OUT=$(get_realpath "$OUT")
 	if [ -e "$PDB_FILE" ]; then
-		PDB_FILE=$(readlink -f "$PDB_FILE")
+		PDB_FILE=$(get_realpath "$PDB_FILE")
 	fi
 
 	# Check that selected ranges are valid.

--- a/scripts/fileinfo.sh
+++ b/scripts/fileinfo.sh
@@ -6,7 +6,7 @@
 #  - is able to analyze archives (.a/.lib files).
 #
 
-SCRIPTPATH="$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )"
+SCRIPTPATH="$(dirname "$(readlink -e "$0")")"
 
 if [ -z "$DECOMPILER_UTILS" ]; then
 	DECOMPILER_UTILS="$SCRIPTPATH/utils.sh"

--- a/scripts/run-unit-tests.sh
+++ b/scripts/run-unit-tests.sh
@@ -3,7 +3,7 @@
 # Runs all the installed unit tests.
 #
 
-SCRIPTPATH="$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )"
+SCRIPTPATH="$(dirname "$(readlink -e "$0")")"
 
 if [ -z "$DECOMPILER_CONFIG" ]; then
 	DECOMPILER_CONFIG="$SCRIPTPATH/config.sh"

--- a/scripts/signature-from-library.sh
+++ b/scripts/signature-from-library.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SCRIPTPATH="$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )"
+SCRIPTPATH="$(dirname "$(readlink -e "$0")")"
 
 if [ -z "$DECOMPILER_UTILS" ]; then
 	DECOMPILER_UTILS="$SCRIPTPATH/utils.sh"
@@ -97,7 +97,7 @@ if [ -z "$OUT_PATH" ]; then
 	die_with_error_and_cleanup "option -o|--output is compulsory"
 else
 	FILE_PATH="$OUT_PATH"
-	DIR="$(dirname "$(readlink -f "$FILE_PATH")")"
+	DIR="$(dirname "$(get_realpath "$FILE_PATH")")"
 	DIR_PATH=$(mktemp -d "$DIR/XXXXXXXXX")
 fi
 

--- a/scripts/unpack.sh
+++ b/scripts/unpack.sh
@@ -26,7 +26,7 @@ RET_UNPACKER_FAILED=4
 # 10 other errors
 #RET_OTHER_ERRORS=10
 
-SCRIPTPATH="$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )"
+SCRIPTPATH="$(dirname "$(readlink -e "$0")")"
 
 if [ -z "$DECOMPILER_UTILS" ]; then
 	DECOMPILER_UTILS="$SCRIPTPATH/utils.sh"
@@ -64,8 +64,8 @@ check_arguments()
 	OUT=${OUT:="$IN"-unpacked}
 
 	# Convert to absolute paths.
-	IN=$(readlink -f "$IN")
-	OUT=$(readlink -f "$OUT")
+	IN=$(get_realpath "$IN")
+	OUT=$(get_realpath "$OUT")
 }
 
 #

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -3,13 +3,23 @@
 # Compilation and decompilation utility functions.
 #
 
-SCRIPTPATH="$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )"
+SCRIPTPATH="$(dirname "$(readlink -e "$0")")"
 
 if [ -z "$DECOMPILER_CONFIG" ]; then
 	DECOMPILER_CONFIG="$SCRIPTPATH/config.sh"
 fi
 
 . "$DECOMPILER_CONFIG"
+
+get_realpath()
+{
+  local inpath="$1"
+  if [[ "$(uname -s)" == *CYGWIN* ]]; then
+    cygpath -ma "$inpath"
+  else
+    readlink -f "$inpath"
+  fi
+}
 
 #
 # Print error message to stderr and die.

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -11,14 +11,22 @@ fi
 
 . "$DECOMPILER_CONFIG"
 
+#
+# return the real, physical  location of a folder or file, relative, or absolute.        
+# 
 get_realpath()
 {
-  local inpath="$1"
-  if [[ "$(uname -s)" == *CYGWIN* ]]; then
-    cygpath -ma "$inpath"
-  else
-    readlink -f "$inpath"
-  fi
+	local inpath="$1"
+	# uses cygpath.exe on cygwin, due to cgwins virtual folder mountpoints
+	# (i.e., "/cygdrive/c/foo/bar" becomes "c:/foo/bar")
+	# cygpath args:
+	#   "-m" = mixed mode, that is, forward slashes, instead of backward slashes.
+	#   "-a" = absolute path (regardless if input is relative or not).    
+	if [[ "$(uname -s)" == *CYGWIN* ]]; then
+		cygpath -ma "$inpath"
+	else
+		readlink -f "$inpath"
+	fi
 }
 
 #


### PR DESCRIPTION
Right now, the scripts used by retdec (decompile.sh, unpack.sh, etc) will fail if they're symlinked, i.e., `decompile.sh` symlinked to `~/retdec-decompile`, because both `${BASH_SOURCE}` and `$0` will always point at the symlinked path, rather than the original, so `$SCRIPTPATH` would become invalid.

This is easy enough to fix, by doing `dirname "$(readlink -e "$0")"`, rather than the pretty ancient style of `cd`ing to `dirname "$0"` (pretty sure this has been out of date since the inception of Linux itself ...).  
The other problem is that the scripts will also fail on Cygwin, due to cygwin's virtual paths (`c:` becomes `/cygdrive/c/`, and so on), which are *not* transformed by readlink. Instead, one needs to use cygpath, to get the real windows path. So I've added `get_realpath` to `utils.sh`, to check if the scripts are running on Cygwin, and if they do, to use `cygpath -ma` (`-a` = absolute path, and `-m` = mixed, i.e., forward slashes rather than backward slashes). Otherwise it just uses `readlink`.

Maybe this isn't the best way, but it makes retdec usable on Cygwin, and especially for anyone symlinking the scripts.