### PR TITLE
expand citability by adding CITATION file

### DIFF
--- a/CITATION
+++ b/CITATION
@@ -1,0 +1,8 @@
+@Misc{RETDEC_BOTCONF_17,
+    author = {J. K\v{r}oustek and P. Matula and P. Zemek},
+    title = {RetDec: An Open-Source Machine-Code Decompiler},
+    year = {2017},
+    month = {December},
+    howpublished = {[talk]},
+    note = {Presented at Botconf 2017, Montpellier, FR}
+}

--- a/CITATION
+++ b/CITATION
@@ -1,4 +1,4 @@
-@Software{RetDec,
+@Misc{RetDec,
     author = {{Avast Software}},
     title = {{RetDec}: A Retargetable Machine-Code Decompiler},
     howpublished = {\url{https://retdec.com/}}

--- a/CITATION
+++ b/CITATION
@@ -1,8 +1,5 @@
-@Misc{RETDEC_BOTCONF_17,
-    author = {J. K\v{r}oustek and P. Matula and P. Zemek},
-    title = {RetDec: An Open-Source Machine-Code Decompiler},
-    year = {2017},
-    month = {December},
-    howpublished = {[talk]},
-    note = {Presented at Botconf 2017, Montpellier, FR}
+@Software{RetDec,
+    author = {{Avast Software}},
+    title = {{RetDec}: A Retargetable Machine-Code Decompiler},
+    howpublished = {\url{https://retdec.com/}}
 }


### PR DESCRIPTION
Hello!

This is a copy your 2017 entry on https://retdec.com/publications/ incorporated into the repo as suggested in https://www.software.ac.uk/blog/2013-09-02-encouraging-citation-software-introducing-citation-files. Adding it here may make it simpler for people to cite your software. How about it?

Also, it would be possible edit this PR to:

- [ ] use `@software{...`
- [ ] add a DOI through https://guides.github.com/activities/citable-code/
- [x] include a `url = {...}`

Cheers!