### PR TITLE
Use `gsha256sum` instead of `sha256sum` if it's available.

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Packages should be preferably installed via [Homebrew](https://brew.sh).
 * [Bison](https://www.gnu.org/software/bison/) (version >= 3.0)
 * [Flex](https://www.gnu.org/software/flex/) (version >= 2.6)
 * [autotools](https://en.wikipedia.org/wiki/GNU_Build_System) ([autoconf](https://www.gnu.org/software/autoconf/autoconf.html), [automake](https://www.gnu.org/software/automake/), and [libtool](https://www.gnu.org/software/libtool/))
-* [coreutils](https://www.gnu.org/software/coreutils) (ensure that you have `$(brew --prefix coreutils)/libexec/gnubin` in your `PATH`)
+* [coreutils](https://www.gnu.org/software/coreutils)
 * [wget](https://www.gnu.org/software/wget/)
 * Optional: [Doxygen](http://www.stack.nl/~dimitri/doxygen/) and [Graphviz](http://www.graphviz.org/) for generating API documentation
 

--- a/cmake/install-share.sh
+++ b/cmake/install-share.sh
@@ -74,7 +74,9 @@ fi
 
 # Compute hash of the downloaded archive.
 echo "Verfifying archive's checksum ..."
-SHA256SUM=$(sha256sum "$SUPPORT_DIR/$ARCH_NAME" | cut -d' ' -f1)
+SHA256SUM_COMMAND=sha256sum
+command -v gsha256sum >&/dev/null && SHA256SUM_COMMAND=gsha256sum
+SHA256SUM=$($SHA256SUM_COMMAND "$SUPPORT_DIR/$ARCH_NAME" | cut -d' ' -f1)
 SHA256SUM_RC=$?
 if [ "$SHA256SUM_RC" -ne 0 ]; then
 	echo "ERROR: sha256sum failed"


### PR DESCRIPTION
GNU coreutils are sometimes installed prefixed with 'g', including on macOS with Homebrew and on BSDs.  The README was recently changed to suggest adding `$(brew --prefix coreutils)/libexec/gnubin` to $PATH (see #75), but this way is better as it works with the default PATH.

Also remove that bit from the README.

(This still requires coreutils to be installed through Homebrew.  #75 originally proposed to use a different utility to compute SHA256 hashes on macOS, but @s3rvac expressed a desire to standardize on coreutils.  Makes sense, but it's still good to minimize the number of manual steps required to successfully build, so I thought this was a reasonable compromise.)