### PR TITLE
Let realpath allocate a buffer itself

### DIFF
--- a/src/utils/filesystem_path.cpp
+++ b/src/utils/filesystem_path.cpp
@@ -168,9 +168,15 @@ public:
 
 	virtual std::string getAbsolutePath() override
 	{
+#ifdef PATH_MAX
 		char absolutePath[PATH_MAX] = { '\0' };
 		if (realpath(_path.c_str(), absolutePath) == nullptr)
 			return {};
+#else
+		char* absolutePathStr = realpath(_path.c_str(), nullptr);
+		std::string absolutePath = absolutePathStr;
+		free(absolutePathStr);
+#endif
 
 		return absolutePath;
 	}


### PR DESCRIPTION
Forwarded from https://bugs.debian.org/888067

`realpath` has the ability to allocate buffer itself. This could avoid depending on fix-sized buffer.