### PR TITLE
Verify digital signature after we have a signer/counter-signer to fix fileinfo crashes

### DIFF
--- a/src/fileformat/file_format/pe/pe_format.cpp
+++ b/src/fileformat/file_format/pe/pe_format.cpp
@@ -975,8 +975,6 @@ void PeFormat::loadCertificates()
 		return;
 	}
 
-	signatureVerified = verifySignature(p7);
-
 	// Find signer of the application and store its serial number.
 	X509 *signerCert = nullptr;
 	X509 *counterSignerCert = nullptr;
@@ -1020,6 +1018,12 @@ void PeFormat::loadCertificates()
 		BIO_free(bio);
 		return;
 	}
+
+	// Now that we know there is at least a signer or counter-signer, we can
+	// verify the signature. Do not try to verify the signature before
+	// verifying that there is at least a signer or counter-signer as 'p7' is
+	// empty in that case (#87).
+	signatureVerified = verifySignature(p7);
 
 	// Create hash table with key-value pair as subject-X509 certificate so we can easily lookup certificates by their subject name
 	std::unordered_map<std::string, X509*> subjectToCert;


### PR DESCRIPTION
In #87, `fileinfo` crashes are reported when verifying the digital signature of attached PE files. What all the attached files have in common is that we are unable to find a signer or counter-signer for them and `p7->length` is `0`. As the following comment in `pe_format.cpp` suggests, there is no point of continuing in such a case:
```
// If we have no signer and countersigner, there must be something really bad
if(!signerCert && !counterSignerCert)
{
    BIO_free(bio);
    return;
}
```
Thus, move the signature verification AFTER the check that we have found a signer or a counter-signer. This fixes the signature-verifying crashes for all the files attached to #87.
