### PR TITLE
Add support for limiting overall memory when running decompilations and tools

### DIFF
--- a/include/retdec/utils/memory.h
+++ b/include/retdec/utils/memory.h
@@ -1,0 +1,22 @@
+/**
+* @file include/retdec/utils/memory.h
+* @brief Memory utilities.
+* @copyright (c) 2017 Avast Software, licensed under the MIT license
+*/
+
+#ifndef RETDEC_UTILS_MEMORY_H
+#define RETDEC_UTILS_MEMORY_H
+
+#include <cstdlib>
+
+namespace retdec {
+namespace utils {
+
+std::size_t getTotalSystemMemory();
+bool limitSystemMemory(std::size_t limit);
+bool limitSystemMemoryToHalfOfTotalSystemMemory();
+
+} // namespace utils
+} // namespace retdec
+
+#endif

--- a/include/retdec/utils/os.h
+++ b/include/retdec/utils/os.h
@@ -17,4 +17,9 @@
 	#define OS_LINUX
 #endif
 
+// It is also useful to know whether the operating system is POSIX compliant.
+#if defined(OS_MACOS) || defined(OS_LINUX)
+	#define OS_POSIX
+#endif
+
 #endif

--- a/src/fileinfo/fileinfo.cpp
+++ b/src/fileinfo/fileinfo.cpp
@@ -10,6 +10,7 @@
 #include <llvm/Support/ErrorHandling.h>
 
 #include "retdec/utils/conversion.h"
+#include "retdec/utils/memory.h"
 #include "retdec/utils/string.h"
 #include "retdec/ar-extractor/detection.h"
 #include "retdec/cpdetect/errors.h"
@@ -48,6 +49,8 @@ struct ProgParams
 	std::set<std::string> yaraMalwarePaths; ///< paths to YARA malware rules
 	std::set<std::string> yaraCryptoPaths;  ///< paths to YARA crypto rules
 	std::set<std::string> yaraOtherPaths;   ///< paths to YARA other rules
+	std::size_t maxMemory;                  ///< maximal memory
+	bool maxMemoryHalfRAM;                  ///< limit maximal memory to half of system RAM
 	LoadFlags loadFlags;                    ///< load flags for `fileformat`
 
 	ProgParams() : searchMode(SearchType::EXACT_MATCH),
@@ -57,6 +60,8 @@ struct ProgParams
 					verbose(false),
 					explanatory(false),
 					generateConfigFile(false),
+					maxMemory(0),
+					maxMemoryHalfRAM(false),
 					loadFlags(LoadFlags::NONE) {}
 };
 
@@ -158,7 +163,13 @@ void printHelp()
 				<< "\n"
 				<< "Options for specifying configuration file:\n"
 				<< "    --config=file, -c=file\n"
-				<< "                          Set path and name of the config which will be (re)generated.\n";
+				<< "                          Set path and name of the config which will be (re)generated.\n"
+				<< "\n"
+				<< "Options for limiting maximal memory:\n"
+				<< "    --max-memory=N\n"
+				<< "                          Limit maximal memory to N bytes (0 means no limit).\n"
+				<< "    --max-memory-half-ram\n"
+				<< "                          Limit maximal memory to half of system RAM.\n";
 }
 
 std::string getParamOrDie(std::vector<std::string> &argv, std::size_t &i)
@@ -197,7 +208,7 @@ bool doParams(int argc, char **_argv, ProgParams &params)
 	std::vector<std::string> argv;
 
 	std::set<std::string> withArgs = {"malware", "m", "crypto", "C", "other",
-			"o", "config", "c", "no-hashes"};
+			"o", "config", "c", "no-hashes", "max-memory"};
 	for (int i = 1; i < argc; ++i)
 	{
 		std::string a = _argv[i];
@@ -289,6 +300,18 @@ bool doParams(int argc, char **_argv, ProgParams &params)
 		{
 			params.yaraOtherPaths.insert(getParamOrDie(argv, i));
 		}
+		else if (c == "--max-memory")
+		{
+			auto maxMemoryString = getParamOrDie(argv, i);
+			auto conversionSucceeded = strToNum(maxMemoryString, params.maxMemory);
+			if (!conversionSucceeded) {
+				return false;
+			}
+		}
+		else if (c == "--max-memory-half-ram")
+		{
+			params.maxMemoryHalfRAM = true;
+		}
 		else if (c == "--no-hashes")
 		{
 			std::string value;
@@ -339,6 +362,24 @@ bool doParams(int argc, char **_argv, ProgParams &params)
 	return true;
 }
 
+/**
+* Limits the maximal memory of the tool based on the command-line parameters.
+*/
+void limitMaximalMemoryIfRequested(const ProgParams& params)
+{
+	// Ignore errors as there is no easy way of reporting them at this
+	// point (in a way that would work both with --plain and --json).
+	// We have at least regression tests for this.
+	if(params.maxMemoryHalfRAM)
+	{
+		limitSystemMemoryToHalfOfTotalSystemMemory();
+	}
+	else if(params.maxMemory > 0)
+	{
+		limitSystemMemory(params.maxMemory);
+	}
+}
+
 } // anonymous namespace
 
 /**
@@ -356,6 +397,8 @@ int main(int argc, char* argv[])
 		printHelp();
 		return static_cast<int>(ReturnCode::ARG);
 	}
+
+	limitMaximalMemoryIfRequested(params);
 
 	bool useConfig = true;
 	retdec::config::Config config;

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -7,6 +7,7 @@ set(RETDEC_UTILS_SOURCES
 	file_io.cpp
 	filesystem_path.cpp
 	math.cpp
+	memory.cpp
 	string.cpp
 	system.cpp
 	time.cpp

--- a/src/utils/memory.cpp
+++ b/src/utils/memory.cpp
@@ -1,0 +1,193 @@
+/**
+* @file src/utils/memory.cpp
+* @brief Memory utilities.
+* @copyright (c) 2017 Avast Software, licensed under the MIT license
+*/
+
+#include "retdec/utils/memory.h"
+#include "retdec/utils/os.h"
+
+#ifdef OS_WINDOWS
+	#include <windows.h>
+#elif defined(OS_MACOS)
+	#include <sys/types.h>
+	#include <sys/sysctl.h>
+#else
+	#include <sys/sysinfo.h>
+#endif
+
+#ifdef OS_POSIX
+	#include <sys/resource.h>
+#endif
+
+namespace retdec {
+namespace utils {
+
+namespace {
+
+#ifdef OS_POSIX
+
+/**
+* @brief Implementation of @c limitSystemMemory() on POSIX-compliant systems.
+*/
+bool limitSystemMemoryOnPOSIX(std::size_t limit) {
+	struct rlimit rl = {
+		.rlim_cur = limit,        // Soft limit.
+		.rlim_max = RLIM_INFINITY // Hard limit (ceiling for rlim_cur).
+	};
+	auto rc = setrlimit(RLIMIT_AS, &rl);
+	return rc == 0;
+}
+
+#endif
+
+#ifdef OS_WINDOWS
+
+/**
+* @brief Implementation of @c getTotalSystemMemory() on Windows.
+*/
+std::size_t getTotalSystemMemoryOnWindows() {
+	MEMORYSTATUSEX memoryStatus;
+	memoryStatus.dwLength = sizeof(memoryStatus);
+	bool succeeded = GlobalMemoryStatusEx(&memoryStatus);
+	return succeeded ? memoryStatus.ullTotalPhys : 0;
+}
+
+/**
+* @brief Assigns the current process into a new job and returns a handle to
+*     that job.
+*
+* When the process cannot be assigned to a job, it returns 0.
+*/
+HANDLE assignProcessToNewJob() {
+	auto jobHandle = CreateJobObject(nullptr, nullptr);
+	if (!jobHandle) {
+		return 0;
+	}
+
+	if (!AssignProcessToJobObject(jobHandle, GetCurrentProcess())) {
+		return 0;
+	}
+
+	return jobHandle;
+}
+
+/**
+* @brief Implementation of @c limitSystemMemory() on Windows.
+*/
+bool limitSystemMemoryOnWindows(std::size_t limit) {
+	// On Windows 7, AssignProcessToJobObject() fails when the current process
+	// has already been attached to a job. Therefore, we have to remember the
+	// job and use it in all subsequent calls to limitSystemMemoryOnWindows().
+	// This is not thread safe, but limitSystemMemory() is already marked as
+	// not reentrant, so we are OK.
+	static auto jobHandle = assignProcessToNewJob();
+
+	JOBOBJECT_EXTENDED_LIMIT_INFORMATION extendedInfo{};
+	extendedInfo.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_PROCESS_MEMORY;
+	extendedInfo.ProcessMemoryLimit = limit;
+
+	auto succeeded = SetInformationJobObject(
+		jobHandle,
+		JobObjectExtendedLimitInformation,
+		&extendedInfo,
+		sizeof(extendedInfo)
+	);
+	return succeeded;
+}
+
+#elif defined(OS_MACOS)
+
+/**
+* @brief Implementation of @c getTotalSystemMemory() on MacOS.
+*/
+std::size_t getTotalSystemMemoryOnMacOS() {
+	int what[] = { CTL_HW, HW_MEMSIZE };
+	std::size_t value = 0;
+	size_t length = sizeof(value);
+	auto rc = sysctl(what, 2, &value, &length, nullptr, 0);
+	return rc != -1 ? value : 0;
+}
+
+/**
+* @brief Implementation of @c limitSystemMemory() on MacOS.
+*/
+bool limitSystemMemoryOnMacOS(std::size_t limit) {
+	return limitSystemMemoryOnPOSIX(limit);
+}
+
+#else
+
+/*
+* @brief Implementation of @c getTotalSystemMemory() on Linux.
+*/
+std::size_t getTotalSystemMemoryOnLinux() {
+    struct sysinfo system_info;
+    auto rc = sysinfo(&system_info);
+    return rc == 0 ? system_info.totalram : 0;
+}
+
+/**
+* @brief Implementation of @c limitSystemMemory() on Linux.
+*/
+bool limitSystemMemoryOnLinux(std::size_t limit) {
+	return limitSystemMemoryOnPOSIX(limit);
+}
+
+#endif
+
+} // anonymous namespace
+
+/**
+* @brief Returns the total size of system RAM (in bytes).
+*
+* When the size cannot be obtained, it returns @c 0.
+*/
+std::size_t getTotalSystemMemory() {
+#ifdef OS_WINDOWS
+	return getTotalSystemMemoryOnWindows();
+#elif defined(OS_MACOS)
+	return getTotalSystemMemoryOnMacOS();
+#else
+	return getTotalSystemMemoryOnLinux();
+#endif
+}
+
+/**
+* @brief Limits system memory to the given size (in bytes).
+*
+* @return @c true if the limiting succeeded, @c false otherwise.
+*
+* When @a limit is @c 0, it immediately returns @c false.
+*
+* This function is not reentrant, i.e. it is not safe to call it simultaneously
+* from multiple threads.
+*/
+bool limitSystemMemory(std::size_t limit) {
+	if (limit == 0) {
+		return false;
+	}
+
+#ifdef OS_WINDOWS
+	return limitSystemMemoryOnWindows(limit);
+#elif defined(OS_MACOS)
+	return limitSystemMemoryOnMacOS(limit);
+#else
+	return limitSystemMemoryOnLinux(limit);
+#endif
+}
+
+/**
+* @brief Limits system memory to half of the total memory.
+*/
+bool limitSystemMemoryToHalfOfTotalSystemMemory() {
+	auto totalSize = getTotalSystemMemory();
+	if (totalSize == 0) {
+		return false;
+	}
+
+	return limitSystemMemory(totalSize / 2);
+}
+
+} // namespace utils
+} // namespace retdec

--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -9,6 +9,7 @@ set(RETDEC_TESTS_UTILS_SOURCES
 	conversion_tests.cpp
 	filter_iterator_tests.cpp
 	math_tests.cpp
+	memory_tests.cpp
 	range_tests.cpp
 	scope_exit_tests.cpp
 	string_tests.cpp

--- a/tests/utils/memory_tests.cpp
+++ b/tests/utils/memory_tests.cpp
@@ -1,0 +1,68 @@
+/**
+* @file tests/utils/memory_tests.cpp
+* @brief Tests for the @c memory module.
+* @copyright (c) 2017 Avast Software, licensed under the MIT license
+*/
+
+#include <gtest/gtest.h>
+
+#include "retdec/utils/memory.h"
+
+using namespace ::testing;
+
+namespace retdec {
+namespace utils {
+namespace tests {
+
+/**
+* @brief Tests for the @c memory module.
+*/
+class MemoryTests: public Test {
+protected:
+	virtual void SetUp() override {
+		// Several tests have side effects, so we need to store the original
+		// total memory so we can restore it after each test.
+		totalSystemMemory = getTotalSystemMemory();
+	}
+
+	virtual void TearDown() override {
+		limitSystemMemory(totalSystemMemory);
+	}
+
+private:
+	/// Original total memory in the system.
+	std::size_t totalSystemMemory = 0;
+};
+
+TEST_F(MemoryTests,
+GetTotalSystemMemoryReturnsNonZeroSize) {
+	auto size = getTotalSystemMemory();
+
+	ASSERT_GT(size, 0);
+}
+
+TEST_F(MemoryTests,
+LimitSystemMemoryReturnsTrueWhenLimitingTotalSystemMemoryToNonZeroSize) {
+	auto totalSize = getTotalSystemMemory();
+
+	// This has a side effect, but the system's memory is set back to the
+	// original value in TearDown().
+	ASSERT_TRUE(limitSystemMemory(totalSize))
+		<< "failed to limit system memory to " << totalSize;
+}
+
+TEST_F(MemoryTests,
+LimitSystemMemoryReturnsFalseWhenLimitIsZero) {
+	ASSERT_FALSE(limitSystemMemory(0));
+}
+
+TEST_F(MemoryTests,
+LimitSystemMemoryToHalfOfTotalSystemMemoryReturnsTrue) {
+	// This has a side effect, but the system's memory is set back to the
+	// original value in TearDown().
+	ASSERT_TRUE(limitSystemMemoryToHalfOfTotalSystemMemory());
+}
+
+} // namespace tests
+} // namespace utils
+} // namespace retdec


### PR DESCRIPTION
Adds support for limiting overall memory when running decompilations and tools (#270).

Details:
* Added a new module `memory` into `retdec::utils`, which provides ways of limiting the available memory of the current process. Supported platforms are Windows, Linux, and macOS.
* Added new parameters `--max-memory` and `--max-memory-half-ram` into `retdec-fileinfo`. By default, there is no memory limit when you run the tool.
* Added new parameters `-max-memory` and `-max-memory-half-ram` into `retdec-bin2llvmir` and `retdec-llvmir2hll`. By default, there is no memory limit when you run the tools.
* Added new parameters `--max-memory` and `--no-memory-limit` into `retdec-decompiler.sh` By default, the script limits the memory of the above tools into half of system RAM to prevent potential black screens (especially on Windows). Use `--no-memory-limit` to remove this limit.
* Regression tests are in the `issue-270-limiting-overall-memory` branch, which will have to be merged after this PR is merged.
