### PR TITLE
Disable forced reconfiguration of LLVM to speed up build and installation

### DIFF
--- a/deps/llvm/CMakeLists.txt
+++ b/deps/llvm/CMakeLists.txt
@@ -90,25 +90,6 @@ ExternalProject_Add(llvm-project
 	INSTALL_COMMAND ""
 )
 
-# Forces a configure step for the given external project.
-# The configure step for external projects is needed to (1) detect source-file
-# changes and (2) fix infinite recursion of 'make' after a terminated build.
-macro(force_configure_step target)
-	# This solution is based on
-	# http://comments.gmane.org/gmane.comp.programming.tools.cmake.user/43024
-	ExternalProject_Add_Step(${target} force-configure
-		COMMAND ${CMAKE_COMMAND} -E echo "Force configure of ${target}"
-		DEPENDEES update
-		DEPENDERS configure
-		ALWAYS 1
-	)
-endmacro()
-
-# We need to force the configuration step for LLVM. Otherwise, if we changed
-# LLVM sources, they would not be rebuilt. This also fixes infinite recursion
-# when running make after an interrupted LLVM build.
-force_configure_step(llvm-project)
-
 # Add libraries.
 ExternalProject_Get_Property(llvm-project binary_dir)
 


### PR DESCRIPTION
This was a relict from our old build system, where we built LLVM as an external project from a subdirectory and needed to detect changes in its source files. Now, we build LLVM as an external project from a GitHub URL, so there is no longer a need to re-configure LLVM after it has been built (its sources will never change).

This speeds up the rebuild and installation of RetDec. For example, on my Linux machine, a rebuild without changes has speeded up from

	real    0m1.223s
	user    0m2.956s
	sys     0m1.163s

to

	real    0m0.527s
	user    0m1.903s
	sys     0m0.716s

On Windows, the difference will be even bigger. This lowering of rebuild times is very handy during development.
