### PR TITLE
Do not remove the input file when --cleanup is used together with --mode raw (#309)

### DIFF
--- a/scripts/retdec-decompiler.sh
+++ b/scripts/retdec-decompiler.sh
@@ -235,7 +235,6 @@ cleanup()
 		fi
 		rm -f "$OUT_BACKEND_BC"
 		rm -f "$OUT_BACKEND_LL"
-		rm -f "$OUT_RAW_EXECUTABLE"		# Mode "raw"
 		rm -f "$OUT_RESTORED"			# Archive support
 		rm -f "$OUT_ARCHIVE"			# Archive support (Macho-O Universal)
 		rm -f "${SIGNATURES_TO_REMOVE[@]}"	# Signatures generated from archives
@@ -797,14 +796,9 @@ fi
 
 # Raw.
 if [ "$MODE" = "raw" ]; then
-	# Default values and initialization.
-	OUT_RAW_EXECUTABLE="$IN"
-
 	# Entry point for THUMB must be odd.
 	[ "$ARCH" = "thumb" ] && [ $((RAW_ENTRY_POINT % 2)) -eq 0 ] && RAW_ENTRY_POINT=$((RAW_ENTRY_POINT+1))
 
-	# Enable binary decompilation.
-	IN="$OUT_RAW_EXECUTABLE"
 	KEEP_UNREACHABLE_FUNCS=1
 fi
 


### PR DESCRIPTION
When `--cleanup` is used together with `--mode raw`, the input file gets removed (see #309). This PR fixes that by removing the `OUT_RAW_EXECUTABLE` variable from `retdec-decompiler.sh`, which is only set to `$IN` at the beginning of a decompilation and serves no real purpose. It was probably a relict from the past when we supported "raw" decompilations from C source code.

Fixes #309.
