### PR TITLE
Use FilesystemPath::exists() instead of fileExists() (#317)

### DIFF
--- a/include/retdec/demangler/demtools.h
+++ b/include/retdec/demangler/demtools.h
@@ -24,8 +24,6 @@ struct sdate_t {
 	unsigned int s = 0;
 };
 
-bool fileExists(const std::string &filename);
-
 void initSdate_t(sdate_t &x);
 
 sdate_t genTimeStruct();

--- a/include/retdec/utils/file_io.h
+++ b/include/retdec/utils/file_io.h
@@ -192,8 +192,6 @@ template <typename N> bool writeFile(const std::string& fileName, const std::vec
 	return ret;
 }
 
-bool fileExists(const std::string& file);
-
 } // namespace utils
 } // namespace retdec
 

--- a/src/demangler/CMakeLists.txt
+++ b/src/demangler/CMakeLists.txt
@@ -9,4 +9,5 @@ set(DEMANGLER_SOURCES
 )
 
 add_library(retdec-demangler STATIC ${DEMANGLER_SOURCES})
+target_link_libraries(retdec-demangler retdec-utils)
 target_include_directories(retdec-demangler PUBLIC ${PROJECT_SOURCE_DIR}/include/)

--- a/src/demangler/demtools.cpp
+++ b/src/demangler/demtools.cpp
@@ -17,16 +17,6 @@ namespace retdec {
 namespace demangler {
 
 /**
- * @brief Function which finds out whether a file exists.
- * @param filename Name of the file to be checked.
- * @return Boolean value determining whether the file exists or not.
- */
-bool fileExists(const std::string &filename) {
-	ifstream ifile(filename);
-	return ifile.is_open();
-}
-
-/**
  * @brief Initializes a sdate_t to default values.
  * @param x sdate_t to be initialized..
  */

--- a/src/demangler/gparser.cpp
+++ b/src/demangler/gparser.cpp
@@ -18,6 +18,7 @@
 #include <sstream>
 #include <string>
 
+#include "retdec/utils/filesystem_path.h"
 #include "retdec/demangler/demglobal.h"
 #include "retdec/demangler/demtools.h"
 #include "retdec/demangler/gparser.h"
@@ -29,6 +30,7 @@
 #define BSUBMAX 40 //max size of parameter substitution vector
 
 using namespace std;
+using namespace retdec::utils;
 
 namespace retdec {
 namespace demangler {
@@ -1928,11 +1930,11 @@ cGram::errcode cGram::generateIgrammar(const string inputfilename, const string 
 	errcode retvalue = ERROR_OK;
 
 	//if the output files already exist, end with error. overwriting is not allowed
-	if (fileExists("stgrammars/"+outputname+"ll.cpp")) {
+	if (FilesystemPath("stgrammars/"+outputname+"ll.cpp").exists()) {
 		errString = string("") + "Igrammar file " + "stgrammars/"+outputname+"ll.cpp" + " already exists.";
 		return ERROR_FILE;
 	}
-	if (fileExists("stgrammars/"+outputname+"ll.h")) {
+	if (FilesystemPath("stgrammars/"+outputname+"ll.h").exists()) {
 		errString = string("") + "Igrammar file " + "stgrammars/"+outputname+"ll.h" + " already exists.";
 		return ERROR_FILE;
 	}

--- a/src/utils/file_io.cpp
+++ b/src/utils/file_io.cpp
@@ -9,15 +9,5 @@
 namespace retdec {
 namespace utils {
 
-/**
- * Does the provided file exist?
- * @param file Path to the file.
- */
-bool fileExists(const std::string& file)
-{
-	std::ifstream f(file);
-	return f.good();
-}
-
 } // namespace utils
 } // namespace retdec


### PR DESCRIPTION
Fix https://github.com/avast-tl/retdec/issues/317 by replacing all `fileExists `method calls with `FilesystemPath::exists()`