### PR TITLE
Fix comparison of vtables and comparison of vtable items.

### DIFF
--- a/src/config/vtables.cpp
+++ b/src/config/vtables.cpp
@@ -117,7 +117,7 @@ bool VtableItem::operator<(const VtableItem& o) const
  */
 bool VtableItem::operator==(const VtableItem& o) const
 {
-	return getAddress() == getAddress();
+	return getAddress() == o.getAddress();
 }
 
 //
@@ -201,7 +201,7 @@ bool Vtable::operator<(const Vtable& o) const
  */
 bool Vtable::operator==(const Vtable& o) const
 {
-	return getAddress() == getAddress();
+	return getAddress() == o.getAddress();
 }
 
 //


### PR DESCRIPTION
There were identical sub-expressions to the left and to the right of the '==' operator. In other words, vtable item/vtable was compared with itself (that results to 'true') instead of comparison with other vtable item/vtable.