### PR TITLE
Fix comparison of ValueData objects.

### DIFF
--- a/src/llvmir2hll/analysis/value_analysis.cpp
+++ b/src/llvmir2hll/analysis/value_analysis.cpp
@@ -118,11 +118,11 @@ bool ValueData::operator==(const ValueData &other) const {
 		dirAllVars == other.dirAllVars &&
 		dirNumOfVarUses == other.dirNumOfVarUses &&
 		mayBeReadVars == other.mayBeReadVars &&
-		mayBeWrittenVars == mayBeWrittenVars &&
-		mayBeAccessedVars == mayBeAccessedVars &&
+		mayBeWrittenVars == other.mayBeWrittenVars &&
+		mayBeAccessedVars == other.mayBeAccessedVars &&
 		mustBeReadVars == other.mustBeReadVars &&
-		mustBeWrittenVars == mustBeWrittenVars &&
-		mustBeAccessedVars == mustBeAccessedVars &&
+		mustBeWrittenVars == other.mustBeWrittenVars &&
+		mustBeAccessedVars == other.mustBeAccessedVars &&
 		calls == other.calls &&
 		addressTakenVars == other.addressTakenVars &&
 		containsDerefs == other.containsDerefs &&


### PR DESCRIPTION
There were identical sub-expressions to the left and to the right of the '==' operator. In other words, several ValueData fields were compared with themselves (that results to 'true') instead of comparison with fields of another ValueData object.