### PR TITLE
Fix possible memory leak in MachOFormat::symtabCommand() method.

### DIFF
--- a/src/fileformat/file_format/macho/macho_format.cpp
+++ b/src/fileformat/file_format/macho/macho_format.cpp
@@ -697,7 +697,6 @@ void MachOFormat::loadDylibCommand(const llvm::object::MachOObjectFile::LoadComm
  */
 void MachOFormat::symtabCommand()
 {
-	auto *symbolTable = new SymbolTable();
 	auto command = file->getSymtabLoadCommand();
 	const char *strPtr = fileBuffer.get()->getBufferStart() + command.stroff + chosenArchOffset;
 	const char *endPtr = chosenArchSize ? fileBuffer.get()->getBufferStart() + chosenArchOffset + chosenArchSize : fileBuffer.get()->getBufferEnd();
@@ -706,6 +705,7 @@ void MachOFormat::symtabCommand()
 		return;
 	}
 
+	auto *symbolTable = new SymbolTable();
 	llvm::StringRef strTable = llvm::StringRef(strPtr, endPtr - strPtr);
 	const char *ptr = fileBuffer.get()->getBufferStart() + command.symoff + chosenArchOffset;
 


### PR DESCRIPTION
The symtabCommand method was exited without releasing the 'symbolTable' pointer.