### PR TITLE
Fix of memory leak in Capstone2LlvmIrTranslator.

### DIFF
--- a/src/capstone2llvmir/capstone2llvmir_impl.cpp
+++ b/src/capstone2llvmir/capstone2llvmir_impl.cpp
@@ -170,6 +170,7 @@ Capstone2LlvmIrTranslator_impl<CInsn, CInsnOp>::translate(
 			return res;
 		}
 
+		cs_free(insn, 1); // release previously allocated memory
 		insn = cs_malloc(_handle);
 
 		// TODO: hack, solve better.


### PR DESCRIPTION
The 'insn' pointer was assigned values N-times without releasing the memory.
Fixes (part of?) memory leaks mentioned in #164, for example:

> ==22520== 11,046,552 (1,272,480 direct, 9,774,072 indirect) bytes in 5,302 blocks are definitely lost in loss record 1,245 of 1,245
> ==22520==    at 0x4C2CEDF: malloc (vg_replace_malloc.c:299)
> ==22520==    by 0x693D53: cs_malloc (in retdec-bin2llvmir)
> ==22520==    by 0x64EA29: retdec::capstone2llvmir::Capstone2LlvmIrTranslator::translate(std::vector<unsigned char, std::allocator<unsigned char> > const&, retdec::utils::Address, llvm::IRBuilder<llvm::ConstantFolder, llvm::IRBuilderDefaultInserter>&, bool) (capstone2llvmir.cpp:881)
> ==22520==    by 0x2C386B: retdec::bin2llvmir::Decoder::doDecoding() (decoder.cpp:1324)
> ==22520==    by 0x2BE092: retdec::bin2llvmir::Decoder::run() (decoder.cpp:109)
> ==22520==    by 0x2BDFDC: retdec::bin2llvmir::Decoder::runCatcher() (decoder.cpp:69)
> ==22520==    by 0x2BDF66: retdec::bin2llvmir::Decoder::runOnModule(llvm::Module&) (decoder.cpp:49)
> ==22520==    by 0x10BDB60: llvm::legacy::PassManagerImpl::run(llvm::Module&) (in retdec-bin2llvmir)
> ==22520==    by 0x201B24: _main(int, char**) (bin2llvmir.cpp:465)
> ==22520==    by 0x201E95: main (bin2llvmir.cpp:483)