### PR TITLE
Fix of memory leak in DebugFormat.

### DIFF
--- a/include/retdec/debugformat/debugformat.h
+++ b/include/retdec/debugformat/debugformat.h
@@ -36,6 +36,7 @@ class DebugFormat
 				SymbolTable* symtab,
 				retdec::demangler::CDemangler* demangler,
 				unsigned long long imageBase = 0);
+		~DebugFormat();
 
 		retdec::config::Function* getFunction(retdec::utils::Address a);
 		const retdec::config::Object* getGlobalVar(retdec::utils::Address a);

--- a/src/debugformat/debugformat.cpp
+++ b/src/debugformat/debugformat.cpp
@@ -57,6 +57,12 @@ DebugFormat::DebugFormat(
 	loadSymtab();
 }
 
+DebugFormat::~DebugFormat()
+{
+	delete _pdbFile;
+	delete _dwarfFile;
+}
+
 /**
  * @return @c True if debug info was loaded successfully from PDB or DWARF.
  *         @c False otherwise.


### PR DESCRIPTION
Destructor was missing, that's why created _pdbFile and _dwarfFile objects were never destroyed.

As well as PR #334 this one partially related to #164, for example:

> ==22520== 106,028 (808 direct, 105,220 indirect) bytes in 1 blocks are definitely lost in loss record 1,240 of 1,245
> ==22520==    at 0x4C2D54F: operator new(unsigned long) (vg_replace_malloc.c:334)
> ==22520==    by 0x463F34: retdec::debugformat::DebugFormat::DebugFormat(retdec::loader::Image*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::map<retdec::utils::Address, retdec::fileformat::Symbol const*, std::less<retdec::utils::Address>, std::allocator<std::pair<retdec::utils::Address const, retdec::fileformat::Symbol const*> > >*, retdec::demangler::CDemangler*, unsigned long long) (debugformat.cpp:43)
> ==22520==    by 0x3E8D09: retdec::bin2llvmir::DebugFormat::DebugFormat(retdec::loader::Image*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::map<retdec::utils::Address, retdec::fileformat::Symbol const*, std::less<retdec::utils::Address>, std::allocator<std::pair<retdec::utils::Address const, retdec::fileformat::Symbol const*> > >*, retdec::demangler::CDemangler*, unsigned long long) (debugformat.h:20)
> ==22520==    by 0x3E880A: retdec::bin2llvmir::DebugFormatProvider::addDebugFormat(llvm::Module*, retdec::loader::Image*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, retdec::utils::Address const&, retdec::demangler::CDemangler*) (debugformat.cpp:49)
> ==22520==    by 0x37A2EB: retdec::bin2llvmir::ProviderInitialization::runOnModule(llvm::Module&) (provider_init.cpp:87)
> ==22520==    by 0x10BDB60: llvm::legacy::PassManagerImpl::run(llvm::Module&) (in retdec-bin2llvmir)
> ==22520==    by 0x201B24: _main(int, char**) (bin2llvmir.cpp:465)
> ==22520==    by 0x201E95: main (bin2llvmir.cpp:483)