### PR TITLE
Fix compiler warning (unused variable 'ai')

### DIFF
--- a/src/bin2llvmir/optimizations/decoder/ir_modifications.cpp
+++ b/src/bin2llvmir/optimizations/decoder/ir_modifications.cpp
@@ -477,8 +477,16 @@ llvm::Function* Decoder::splitFunctionOn(utils::Address addr)
 	//
 	else if (auto ai = AsmInstruction(_module, addr))
 	{
-		LOG << "\t\t\t\t" << "S: ASM @ " << addr << std::endl;
-		return nullptr;
+		if (ai.isInvalid())
+		{
+			LOG << "\t\t\t\t" << "S: invalid ASM @ " << addr << std::endl;
+			return nullptr;
+		}
+		else
+		{
+			LOG << "\t\t\t\t" << "S: ASM @ " << addr << std::endl;
+			return nullptr;
+		}
 	}
 	else if (getFunctionContainingAddress(addr))
 	{


### PR DESCRIPTION
There was a compiler warning because "ai" never used, So this is a quick fix for that.

Here is the example : 

```
[ 72%] Building CXX object src/fileinfo/CMakeFiles/retdec-fileinfo.dir/file_presentation/file_presentation.cpp.o
/Users/x/Development/retdec/src/bin2llvmir/optimizations/decoder/ir_modifications.cpp:478:16: warning: unused variable 'ai' [-Wunused-variable]
        else if (auto ai = AsmInstruction(_module, addr))

```