### PR TITLE
Eliminate "lib*.a(filexx.cpp.o)" has no symbols on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,14 @@ elseif(UNIX)
 	set(CMAKE_INSTALL_RPATH "$ORIGIN/../lib")
 endif()
 
+# Suppress superfluous randlib warnings about "*.a" having no symbols on MacOSX.
+if (APPLE)
+	set(CMAKE_C_ARCHIVE_CREATE   "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
+	set(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
+	set(CMAKE_C_ARCHIVE_FINISH   "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
+	set(CMAKE_CXX_ARCHIVE_FINISH "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
+endif()
+
 # Build all external projects in the same directory that is directly inside the
 # build directory. This reduces path lengths, which is important on Windows as
 # there is a limit on how long a path can be.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,14 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+function(append_if condition value)
+  if (${condition})
+    foreach(variable ${ARGN})
+      set(${variable} "${${variable}} ${value}" PARENT_SCOPE)
+    endforeach(variable)
+  endif()
+endfunction()
+
 # On Linux and macOS, set RPATH relative to the origin of the installed
 # executables (i.e. relative to the bin directory). This allows us to move the
 # installation directory into a different location after installation, which is
@@ -62,6 +70,12 @@ if(MSVC)
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR
 		CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR
 		CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+	# Unify visibility to meet llvm's default.
+	include(CheckCXXCompilerFlag)
+
+	check_cxx_compiler_flag("-fvisibility-inlines-hidden" SUPPORTS_FVISIBILITY_INLINES_HIDDEN_FLAG)
+	append_if(SUPPORTS_FVISIBILITY_INLINES_HIDDEN_FLAG "-fvisibility-inlines-hidden" CMAKE_CXX_FLAGS)
+
 	# Enable standard warnings.
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
 

--- a/src/bin2llvmir/optimizations/decoder/ir_modifications.cpp
+++ b/src/bin2llvmir/optimizations/decoder/ir_modifications.cpp
@@ -477,8 +477,16 @@ llvm::Function* Decoder::splitFunctionOn(utils::Address addr)
 	//
 	else if (auto ai = AsmInstruction(_module, addr))
 	{
-		LOG << "\t\t\t\t" << "S: ASM @ " << addr << std::endl;
-		return nullptr;
+		if (ai.isInvalid())
+		{
+			LOG << "\t\t\t\t" << "S: invalid ASM @ " << addr << std::endl;
+			return nullptr;
+		}
+		else
+		{
+			LOG << "\t\t\t\t" << "S: ASM @ " << addr << std::endl;
+			return nullptr;
+		}
 	}
 	else if (getFunctionContainingAddress(addr))
 	{


### PR DESCRIPTION
On macOS there is some warnings about object that has no symbols in it, this is needed to be fixed to make building more clean and clear.

example of build log :
```
[ 94%] Linking CXX static library libretdec-bin2llvmir.a
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: libretdec-bin2llvmir.a(idioms_borland.cpp.o) has no symbols
```