### PR TITLE
Fix #41, #169 - Handle pointers with segment override correctly

### DIFF
--- a/src/bin2llvmir/utils/ir_modifier.cpp
+++ b/src/bin2llvmir/utils/ir_modifier.cpp
@@ -71,12 +71,23 @@ Value* convertToType(
 	{
 		if (constExpr)
 		{
-			conv = ConstantExpr::getBitCast(cval, type);
+			if (val->getType()->getPointerAddressSpace() == type->getPointerAddressSpace())
+				conv = ConstantExpr::getBitCast(cval, type);
+			else
+				conv = ConstantExpr::getAddrSpaceCast(cval, type);
 		}
 		else
 		{
-			auto* i = new BitCastInst(val, type, "");
-			conv = insertBeforeAfter(i, before, after);
+			if (val->getType()->getPointerAddressSpace() == type->getPointerAddressSpace())
+			{
+				auto* i = new BitCastInst(val, type, "");
+				conv = insertBeforeAfter(i, before, after);
+			}
+			else
+			{
+				auto* i = new AddrSpaceCastInst(val, type, "");
+				conv = insertBeforeAfter(i, before, after);
+			}
 		}
 	}
 	else if (val->getType()->isPointerTy() && type->isIntegerTy())

--- a/src/capstone2llvmir/x86/x86.cpp
+++ b/src/capstone2llvmir/x86/x86.cpp
@@ -1005,7 +1005,7 @@ llvm::Value* Capstone2LlvmIrTranslatorX86_impl::loadOp(
 				}
 				case X86_REG_SS:
 				{
-					addressSpace = 256;
+					addressSpace = 258;
 					break;
 				}
 				default:

--- a/src/capstone2llvmir/x86/x86_impl.h
+++ b/src/capstone2llvmir/x86/x86_impl.h
@@ -137,6 +137,8 @@ class Capstone2LlvmIrTranslatorX86_impl :
 				llvm::Value* sflagsVal,
 				const std::vector<std::pair<uint32_t, llvm::Value*>>& regs);
 
+		unsigned getAddrSpace(x86_reg segment);
+
 		llvm::Value* loadX87Top(llvm::IRBuilder<>& irb);
 		llvm::Value* loadX87TopDec(llvm::IRBuilder<>& irb);
 		llvm::Value* loadX87TopInc(llvm::IRBuilder<>& irb);

--- a/src/llvmir2hll/llvm/llvmir2bir_converters/orig_llvmir2bir_converter/llvm_converter.cpp
+++ b/src/llvmir2hll/llvm/llvmir2bir_converters/orig_llvmir2bir_converter/llvm_converter.cpp
@@ -182,6 +182,7 @@ ShPtr<Expression> LLVMConverter::llvmConstantToExpression(llvm::Constant *c) {
 				return IntToPtrCastExpr::create(op, llvmTypeToType(ce->getType()));
 
 			case llvm::Instruction::BitCast:
+			case llvm::Instruction::AddrSpaceCast:
 				return BitCastExpr::create(op, llvmTypeToType(ce->getType()));
 
 			case llvm::Instruction::GetElementPtr:


### PR DESCRIPTION
See my analysis of the issue in #41 (#169 seems to be a duplicate). capstone2llvmir currently ignores segment override on pointers like `fs:[0]`. This makes LLVM think that the code is handling null pointers and remove that code as unreachable.

First step was to treat segment overrides correctly, the matching LLVM concept is address spaces. Unfortunately, the only place resembling a documentation for the mapping between segments and address spaces is https://github.com/avast-tl/llvm/blob/725d0cee133c6ab9b95c493f05de3b08016f5c3c/lib/Target/X86/X86ISelDAGToDAG.cpp#L1427, that's what I implemented.

Having address spaces on pointers caused issues further down in the pipeline. bin2llvmir was always producing bitcasts for pointer casts, this had to be changed into address space casts when address spaces change.

And llvmir2hll didn't know address space casts. I made it treat them the same as bitcasts which should do in the short term. In fact, I don't really know how that `add byte ptr gs:[ebx], dh` instruction (the one that produced the address space cast) got into [this driver](https://github.com/avast-tl/retdec-regression-tests/tree/master/features/windrivers) and what it could be converted into.