### PR TITLE
Die as intended on bin2pat error

### DIFF
--- a/src/bin2pat/bin2pat.cpp
+++ b/src/bin2pat/bin2pat.cpp
@@ -41,7 +41,7 @@ int printErrorAndDie(
 {
 	std::cerr << "Error: " << message << ".\n";
 	printUsage(std::cerr);
-	return 1;
+	exit(1);
 }
 
 int needValue(


### PR DESCRIPTION
As described in https://github.com/avast-tl/retdec/issues/473, `bin2pat` does not die correctly when an error is encountered, which affects the running of other scripts.