### PR TITLE
Added option -l --list to retdec-bin2pat.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # dev
 
+* Fix: Added option to `retdec-bin2pat` to have the objects list passed through a text file.
+Modified `retdec-signature-from-library-creator.py` to pass objects list as a text file. ([#472](https://github.com/avast-tl/retdec/issues/472)).
 * New Feature: Added presentation of imported types and TypeRef hashes for .NET binaries ([#363](https://github.com/avast-tl/retdec/issues/363), [#364](https://github.com/avast-tl/retdec/issues/364), [#428](https://github.com/avast-tl/retdec/issues/428)).
 * New Feature: Added computation and presentation of icon hashes for exact and also similarity matching in PE files ([#339](https://github.com/avast-tl/retdec/issues/339)).
 * Enhancement: Added support for build and run on FreeBSD and potentially on other BSD OSes ([#476](https://github.com/avast-tl/retdec/pull/476)).

--- a/scripts/retdec-signature-from-library-creator.py
+++ b/scripts/retdec-signature-from-library-creator.py
@@ -82,6 +82,7 @@ class SigFromLib:
 
         dir_name = os.path.dirname(os.path.abspath(self.args.output))
         self.tmp_dir_path = tempfile.mkdtemp(dir=dir_name)
+        self.object_list_path = os.path.join(self.tmp_dir_path, 'object-list.txt')
 
         if self.args.ignore_nops:
             self.ignore_nop = '--ignore-nops'
@@ -126,7 +127,10 @@ class SigFromLib:
             # Extract patterns from library.
             pattern_file = os.path.join(self.tmp_dir_path, lib_name) + '.pat'
             pattern_files.append(pattern_file)
-            _, result, _ = cmd.run_cmd([config.BIN2PAT, '-o', pattern_file] + objects, discard_stdout=True, discard_stderr=True)
+            with open(self.object_list_path, 'w') as object_list:
+                for item in objects:
+                    object_list.write(item+'\n')
+            _, result, _ = cmd.run_cmd([config.BIN2PAT, '-o', pattern_file, '-l', self.object_list_path], discard_stdout=True, discard_stderr=True)
 
             if result != 0:
                 self.print_error_and_cleanup('utility bin2pat failed when processing %s' % lib_path)

--- a/src/bin2pat/bin2pat.cpp
+++ b/src/bin2pat/bin2pat.cpp
@@ -28,13 +28,16 @@ void printUsage(
 	std::ostream &outputStream)
 {
 	outputStream << "Usage: bin2pat [-o OUTPUT_FILE] [-n NOTE]"
-		<< " INPUT_FILE [INPUT_FILE...]\n\n"
+		<< " <INPUT_FILE [INPUT_FILE...] | -l LIST_FILE>\n\n"
 		<< "-o --output OUTPUT_FILE\n"
 		<< "    Output file path (if not given, stdout is used).\n"
 		<< "    If multiple paths are given, only last one is used.\n\n"
 		<< "-n --note NOTE\n"
 		<< "    Optional note that will be added to all rules.\n"
-		<< "    If multiple notes are given, only last one is used.\n\n";
+		<< "    If multiple notes are given, only last one is used.\n\n"
+		<< "-l --list LIST_FILE\n"
+		<< "    Optionally pass the list of input files as a text file.\n"
+		<< "    This is useful for a large number of input files.\n\n";
 }
 
 void printErrorAndDie(
@@ -79,6 +82,35 @@ void processArgs(
 			else {
 				needValue(args[i]);
 				return;
+			}
+		}
+		else if (args[i] == "-l" || args[i] == "--list") {
+			// Ensure -l --list is not the last thing in args
+			if (&args[i] == &args.back()) {
+				printErrorAndDie("input file missing");
+				return;
+			}
+
+			std::ifstream inputObjects(args[++i]);
+			std::string object;
+
+			if (!inputObjects) {
+				printErrorAndDie("LIST_FILE '" + args[i]
+					+ "' is not a valid file");
+				return;
+			}
+			// Read LIST_FILE until EOF
+			while (std::getline(inputObjects, object)) {
+				// Ensure file exists before proceeding
+				if(!FilesystemPath(object).isFile()) {
+					printErrorAndDie("argument '" + args[i]
+						+ "' contains the filename '" + object
+						+ "' which is not a valid file");
+					return;
+				}
+				else {
+					inPaths.push_back(object);
+				}
 			}
 		}
 		else {


### PR DESCRIPTION
The added option -l --list is being used to pass the list of objects
from retdec-signature-from-library-creator.py as a json file.
Resolves #472 

I am uncertain if the change in retdec-bin2pat's help output correctly
follows the Utility Conventions. If it does not, providing a proper
reference would be appreciated.

Regards,
Andrew Strelsky