### PR TITLE
Change SCC's to be FuncVectorSet instead of FuncSetSet.

### DIFF
--- a/include/retdec/llvmir2hll/obtainer/call_info_obtainer.h
+++ b/include/retdec/llvmir2hll/obtainer/call_info_obtainer.h
@@ -251,8 +251,8 @@ public:
 	virtual ShPtr<FuncInfo> getFuncInfo(ShPtr<Function> func) = 0;
 
 protected:
-	/// Set of sets of functions.
-	using FuncSetSet = std::set<FuncSet>;
+	/// Vector of sets of functions.
+	using FuncVectorSet = std::vector<FuncSet>;
 
 	/**
 	* @brief Represents an order in which FuncInfos should be computed.
@@ -297,7 +297,7 @@ protected:
 		FuncVector order;
 
 		/// SCCs in the call graph.
-		FuncSetSet sccs;
+		FuncVectorSet sccs;
 	};
 
 	/// Mapping of a function into its CFG.
@@ -342,7 +342,23 @@ private:
 	public:
 		~SCCComputer();
 
-		static FuncSetSet computeSCCs(ShPtr<CG> cg);
+		// We use a vector of function sets because:
+		//
+		// 1. Tarjan's algorithm outputs SCCs in a topological order
+		// that we want to maintain.  That is trivial to do if we
+		// add them to the vector in that order.
+		//
+		// 2. It also only creates each SCC once so we don't have to
+		// worry about duplicates.
+		//
+		// 3. Using sets of sets causes non-determinism because it is
+		// comparing sets of pointers against sets of pointers.
+		//
+		// 4. Each insertion of an function set (SCC) into the SCC set
+		// requires Log N comparisons each possibly taking O(N) time due
+		// to how operator < is defined on std::set (lexicographic
+		// compare).
+		static FuncVectorSet computeSCCs(ShPtr<CG> cg);
 
 	private:
 		/// Stack of CalledFuncs.
@@ -366,7 +382,7 @@ private:
 		SCCComputer(ShPtr<CG> cg);
 		void visit(ShPtr<CG::CalledFuncs> calledFunc,
 			CalledFuncInfo &calledFuncInfo);
-		FuncSetSet findSCCs();
+		FuncVectorSet findSCCs();
 
 	private:
 		/// Call graph of the current module.
@@ -376,7 +392,7 @@ private:
 		int index;
 
 		/// The set of computed SCCs.
-		FuncSetSet sccs;
+		FuncVectorSet sccs;
 
 		/// The currently computed SCC.
 		FuncSet currentSCC;
@@ -400,10 +416,10 @@ private:
 	};
 
 private:
-	FuncSetSet computeSCCs();
+	FuncVectorSet computeSCCs();
 	bool callsJustComputedFuncs(ShPtr<Function> func,
 		const FuncSet &computedFuncs) const;
-	SCCWithRepresent findNextSCC(const FuncSetSet &sccs,
+	SCCWithRepresent findNextSCC(const FuncVectorSet &sccs,
 		const FuncSet &computedFuncs, const FuncSet &remainingFuncs) const;
 };
 

--- a/src/llvmir2hll/obtainer/call_info_obtainer.cpp
+++ b/src/llvmir2hll/obtainer/call_info_obtainer.cpp
@@ -240,8 +240,9 @@ bool CallInfoObtainer::callsJustComputedFuncs(ShPtr<Function> func,
 *  - @a remainingFuncs doesn't contain a function which calls just functions
 *    from @a computedFuncs.
 */
-CallInfoObtainer::SCCWithRepresent CallInfoObtainer::findNextSCC(const FuncSetSet &sccs,
-		const FuncSet &computedFuncs, const FuncSet &remainingFuncs) const {
+CallInfoObtainer::SCCWithRepresent CallInfoObtainer::findNextSCC(
+		const FuncVectorSet &sccs, const FuncSet &computedFuncs,
+		const FuncSet &remainingFuncs) const {
 	PRECONDITION(!remainingFuncs.empty(), "it should not be empty");
 
 	//
@@ -287,7 +288,7 @@ CallInfoObtainer::SCCWithRepresent CallInfoObtainer::findNextSCC(const FuncSetSe
 * A single function is not considered to be an SCC unless it contains a call to
 * itself (see the description of FuncInfoCompOrder).
 */
-CallInfoObtainer::FuncSetSet CallInfoObtainer::computeSCCs() {
+CallInfoObtainer::FuncVectorSet CallInfoObtainer::computeSCCs() {
 	return SCCComputer::computeSCCs(cg);
 }
 
@@ -348,7 +349,7 @@ CallInfoObtainer::SCCComputer::~SCCComputer() {}
 * A single function is not considered to be an SCC unless it contains a call to
 * itself (see the description of FuncInfoCompOrder).
 */
-CallInfoObtainer::FuncSetSet CallInfoObtainer::SCCComputer::computeSCCs(
+CallInfoObtainer::FuncVectorSet CallInfoObtainer::SCCComputer::computeSCCs(
 		ShPtr<CG> cg) {
 	PRECONDITION_NON_NULL(cg);
 
@@ -363,7 +364,7 @@ CallInfoObtainer::FuncSetSet CallInfoObtainer::SCCComputer::computeSCCs(
 * A single function is not considered to be an SCC unless it contains a call to
 * itself (see the description of FuncInfoCompOrder).
 */
-CallInfoObtainer::FuncSetSet CallInfoObtainer::SCCComputer::findSCCs() {
+CallInfoObtainer::FuncVectorSet CallInfoObtainer::SCCComputer::findSCCs() {
 	// The following code corresponds to the code from
 	// http://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm
 
@@ -436,7 +437,10 @@ void CallInfoObtainer::SCCComputer::visit(ShPtr<CG::CalledFuncs> calledFunc,
 		// function, do this only if it calls itself (see the description of
 		// computeSCCs()).
 		if (scc.size() != 1 || hasItem(calledFunc->callees, calledFunc->caller)) {
-			sccs.insert(scc);
+			// Tarjan only tries to create each SCC once, so it is
+			// safe to use push_back here - it will never add
+			// duplicates.
+			sccs.push_back(scc);
 		}
 	}
 }


### PR DESCRIPTION
Previously, the set of sccs was sorted by overall function pointer order.
This was one source of non-determinism.
It also  destroyed the topological ordering of SCCs that tarjan creates.

Also, insertion of each funcset (scc) into the tree of funcsetset possibly compared it against log N funcsets, where each comparison is O(N) (The definition of operator< on sets
performs lexicographic compare on all the members of each set).
This did not do well in the face when inserting large sccs since it may walk a many-thousand member set log N times just to determine the funcset's place in the funcsetset tree.

In practice this is a minor time savings but given we don't want them sorted this way anyway ...
