### PR TITLE
Show doxygen.log contents after doxygen documentation is generated

### DIFF
--- a/doc/doxygen/CMakeLists.txt
+++ b/doc/doxygen/CMakeLists.txt
@@ -29,6 +29,12 @@ add_custom_target(doc ALL
 	COMMENT "Generating API documentation with Doxygen" VERBATIM
 )
 
+# Show doxygen log file after the documentation is generated.
+add_custom_command(TARGET doc
+	POST_BUILD
+	COMMAND "${CMAKE_COMMAND}" "-DDOXYGEN_LOG=${DOXYGEN_LOG}" -P "${CMAKE_CURRENT_SOURCE_DIR}/show_doxygen_log.cmake"
+)
+
 # Cleanup.
 set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES "${DOXYGEN_OUTPUT_DIR}")
 

--- a/doc/doxygen/show_doxygen_log.cmake
+++ b/doc/doxygen/show_doxygen_log.cmake
@@ -1,0 +1,6 @@
+file(READ
+	"${DOXYGEN_LOG}"
+	DOXYGEN_LOG_CONTENT
+)
+
+message("${DOXYGEN_LOG_CONTENT}")


### PR DESCRIPTION
Currently, you need to check the contents of `build/doc/doxygen/doxygen.log` to see if you caused any warnings/errors in Doxygen documentation. This change shows the contents of the `doxygen.log` file after `make doc` is finished.