### PR TITLE
TypeRef table reconstruction SEGFAULT fix

### DIFF
--- a/src/fileformat/types/dotnet_types/dotnet_type_reconstructor.cpp
+++ b/src/fileformat/types/dotnet_types/dotnet_type_reconstructor.cpp
@@ -840,6 +840,12 @@ std::unique_ptr<DotnetClass> DotnetTypeReconstructor::createClassReference(const
 	else
 	{
 		auto assemblyRefTable = static_cast<const MetadataTable<AssemblyRef>*>(metadataStream->getMetadataTable(MetadataTableType::AssemblyRef));
+
+		if (!assemblyRefTable)
+		{
+			return nullptr;
+		}
+
 		auto assemblyRef = assemblyRefTable->getRow(typeRef->resolutionScope.getIndex());
 
 		if (!assemblyRef || !stringStream->getString(assemblyRef->name.getIndex(), classLibName))


### PR DESCRIPTION
https://github.com/avast-tl/retdec/issues/458
I've added a check for null in TypeRef table reconstruction to prevenet null dereference.